### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "rust"
+run = "cargo run"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ cargo build // build app
 cargo run // run app
 cargo clearn // clean up target debug folder
 ```
+
+[![Run on Repl.it](https://repl.it/badge/github/Lightnet/rustgunjs)](https://repl.it/github/Lightnet/rustgunjs)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).